### PR TITLE
Fix scrolling bugs

### DIFF
--- a/docs/VirtualList.js
+++ b/docs/VirtualList.js
@@ -443,8 +443,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return this;
 	    }
 	  }, {
-	    key: 'scrollToIndex',
-	    value: function scrollToIndex(index, callback) {
+	    key: '_scrollToIndex',
+	    value: function _scrollToIndex(index, callback) {
 	      var items = this.props.items;
 	      var _state9 = this.state,
 	          winSize = _state9.winSize,
@@ -455,6 +455,23 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var scrollTop = winStart * avgRowHeight;
 
 	      this.setState({ winStart: winStart, scrollTop: scrollTop }, callback);
+	    }
+	  }, {
+	    key: 'scrollToIndex',
+	    value: function scrollToIndex(index, callback) {
+	      var _this4 = this;
+
+	      if (this.state.avgRowHeight === 1) {
+	        // The average row height is still the initial value, which means that we
+	        // haven't sampled the row heights yet, which we need in order to properly
+	        // scroll to the right position. So we need to delay the scroll logic
+	        // until after the list has had a chance to sample the row heights.
+	        this.setState({}, function () {
+	          _this4._scrollToIndex(index, callback);
+	        });
+	      } else {
+	        this._scrollToIndex(index, callback);
+	      }
 	    }
 	  }, {
 	    key: 'scrollToItem',
@@ -514,7 +531,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }, {
 	    key: 'render',
 	    value: function render() {
-	      var _this4 = this;
+	      var _this5 = this;
 
 	      var _props2 = this.props,
 	          items = _props2.items,
@@ -561,7 +578,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        'div',
 	        {
 	          ref: function ref(node) {
-	            _this4.node = node;
+	            _this5.node = node;
 	          },
 	          className: 'VirtualList',
 	          tabIndex: '-1',
@@ -571,7 +588,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	          'div',
 	          {
 	            ref: function ref(content) {
-	              _this4.content = content;
+	              _this5.content = content;
 	            },
 	            className: 'VirtualList-content',
 	            style: contentStyle },

--- a/docs/VirtualList.js
+++ b/docs/VirtualList.js
@@ -445,6 +445,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }, {
 	    key: '_scrollToIndex',
 	    value: function _scrollToIndex(index, callback) {
+	      var _this4 = this;
+
 	      var items = this.props.items;
 	      var _state9 = this.state,
 	          winSize = _state9.winSize,
@@ -454,12 +456,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var winStart = Math.min(maxWinStart, index);
 	      var scrollTop = winStart * avgRowHeight;
 
-	      this.setState({ winStart: winStart, scrollTop: scrollTop }, callback);
+	      this.setState({ winStart: winStart, scrollTop: scrollTop }, function () {
+	        _this4.content.childNodes[index - winStart].scrollIntoView();
+	      });
 	    }
 	  }, {
 	    key: 'scrollToIndex',
 	    value: function scrollToIndex(index, callback) {
-	      var _this4 = this;
+	      var _this5 = this;
 
 	      if (this.state.avgRowHeight === 1) {
 	        // The average row height is still the initial value, which means that we
@@ -467,7 +471,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        // scroll to the right position. So we need to delay the scroll logic
 	        // until after the list has had a chance to sample the row heights.
 	        this.setState({}, function () {
-	          _this4._scrollToIndex(index, callback);
+	          _this5._scrollToIndex(index, callback);
 	        });
 	      } else {
 	        this._scrollToIndex(index, callback);
@@ -516,22 +520,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return this;
 	    }
 	  }, {
-	    key: 'handleScroll',
-	    value: function handleScroll() {
-	      var node = this.node;
-	      var scrollTop = this.state.scrollTop;
-
-
-	      if (node.scrollTop !== scrollTop) {
-	        this.scroll(node.scrollTop - scrollTop);
-	      }
-
-	      this._handleScrollRAF = requestAnimationFrame(this.handleScroll);
-	    }
-	  }, {
 	    key: 'render',
 	    value: function render() {
-	      var _this5 = this;
+	      var _this6 = this;
 
 	      var _props2 = this.props,
 	          items = _props2.items,
@@ -578,7 +569,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        'div',
 	        {
 	          ref: function ref(node) {
-	            _this5.node = node;
+	            _this6.node = node;
 	          },
 	          className: 'VirtualList',
 	          tabIndex: '-1',
@@ -588,7 +579,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	          'div',
 	          {
 	            ref: function ref(content) {
-	              _this5.content = content;
+	              _this6.content = content;
 	            },
 	            className: 'VirtualList-content',
 	            style: contentStyle },

--- a/docs/VirtualList.js
+++ b/docs/VirtualList.js
@@ -328,7 +328,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }, {
 	    key: 'handleScroll',
 	    value: function handleScroll(callback) {
-	      var items = this.props.items;
+	      var _props2 = this.props,
+	          items = _props2.items,
+	          buffer = _props2.buffer;
 
 	      var itemNodes = Array.from(this.content.childNodes).slice(1, -1);
 	      var firstItemNode = itemNodes[0];
@@ -348,8 +350,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	        newWinStart = Math.min(maxWinStart, Math.floor(scrollTop / avgRowHeight));
 	      } else if (firstItemNode && firstItemNode.offsetTop + firstItemNode.offsetHeight > scrollTop) {
 	        // first item is visible, so shift window upwards
-	        for (var i = itemNodes.length - 1; i > 0; i--) {
-	          if (newWinStart > 0 && itemNodes[i].offsetTop > scrollTop + viewportHeight && itemNodes[i - 1].offsetTop > scrollTop + viewportHeight) {
+	        for (var i = 0; i < Math.ceil(buffer / 2); i++) {
+	          if (newWinStart > 0 && itemNodes[itemNodes.length - i - 1].offsetTop > scrollTop + viewportHeight) {
 	            newWinStart--;
 	          } else {
 	            break;
@@ -357,8 +359,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	        }
 	      } else if (lastItemNode && lastItemNode.offsetTop < scrollTop + viewportHeight) {
 	        // last item is visible, so shift window downwards
-	        for (var _i = 0; _i < itemNodes.length - 1; _i++) {
-	          if (newWinStart < maxWinStart && itemNodes[_i].offsetTop + itemNodes[_i].offsetHeight < scrollTop && itemNodes[_i + 1].offsetTop + itemNodes[_i + 1].offsetHeight < scrollTop) {
+	        for (var _i = 0; _i < Math.ceil(buffer / 2); _i++) {
+	          if (newWinStart < maxWinStart && itemNodes[_i].offsetTop + itemNodes[_i].offsetHeight < scrollTop) {
 	            newWinStart++;
 	          } else {
 	            break;
@@ -456,11 +458,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    value: function render() {
 	      var _this6 = this;
 
-	      var _props2 = this.props,
-	          items = _props2.items,
-	          getItem = _props2.getItem,
-	          getItemKey = _props2.getItemKey,
-	          scrollbarOffset = _props2.scrollbarOffset;
+	      var _props3 = this.props,
+	          items = _props3.items,
+	          getItem = _props3.getItem,
+	          getItemKey = _props3.getItemKey,
+	          scrollbarOffset = _props3.scrollbarOffset;
 	      var _state6 = this.state,
 	          winStart = _state6.winStart,
 	          winSize = _state6.winSize,

--- a/docs/VirtualList.js
+++ b/docs/VirtualList.js
@@ -299,7 +299,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 	      for (var i = 0; i < itemNodes.length; i++) {
-	        if (itemNodes[i].offsetTop + itemNodes[i].offsetHeight >= scrollTop) {
+	        if (itemNodes[i].offsetTop + itemNodes[i].offsetHeight > scrollTop) {
 	          return winStart + i;
 	        }
 	      }

--- a/docs/VirtualList.js
+++ b/docs/VirtualList.js
@@ -452,12 +452,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	          winSize = _state9.winSize,
 	          avgRowHeight = _state9.avgRowHeight;
 
-
-	      if (index >= winStart && index < winStart + winSize) {
-	        this.content.childNodes[index - winStart].scrollIntoView();
-	        if (callback) callback();
-	        return;
-	      }
+	      //if (index >= winStart && index < winStart + winSize) {
+	      //  this.content.childNodes[index - winStart].scrollIntoView();
+	      //  if (callback) callback();
+	      //  return;
+	      //}
 
 	      var items = this.props.items;
 

--- a/docs/VirtualList.js
+++ b/docs/VirtualList.js
@@ -447,17 +447,27 @@ return /******/ (function(modules) { // webpackBootstrap
 	    value: function _scrollToIndex(index, callback) {
 	      var _this4 = this;
 
-	      var items = this.props.items;
 	      var _state9 = this.state,
+	          winStart = _state9.winStart,
 	          winSize = _state9.winSize,
 	          avgRowHeight = _state9.avgRowHeight;
 
-	      var maxWinStart = Math.max(0, items.length - winSize);
-	      var winStart = Math.min(maxWinStart, index);
-	      var scrollTop = winStart * avgRowHeight;
 
-	      this.setState({ winStart: winStart, scrollTop: scrollTop }, function () {
-	        _this4.content.childNodes[index - winStart].scrollIntoView();
+	      if (index >= winStart && index < winStart + winSize) {
+	        this.content.childNodes[index - winStart].scrollIntoView();
+	        if (callback) callback();
+	        return;
+	      }
+
+	      var items = this.props.items;
+
+	      var maxWinStart = Math.max(0, items.length - winSize);
+	      var newWinStart = Math.min(maxWinStart, index);
+	      var scrollTop = newWinStart * avgRowHeight;
+
+	      this.setState({ winStart: newWinStart, scrollTop: scrollTop }, function () {
+	        _this4.content.childNodes[index - newWinStart].scrollIntoView();
+	        if (callback) callback();
 	      });
 	    }
 	  }, {

--- a/docs/examples/4.html
+++ b/docs/examples/4.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html class="no-js" lang="">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>VirtualList Example</title>
+    <style>
+    .container {
+      position: absolute;
+      top: 50px;
+      right: 50px;
+      bottom: 50px;
+      left: 50px;
+      border: 1px solid #eee;
+      overflow: hidden;
+    }
+
+    .ItemView {
+      border-bottom: 1px solid #eee;
+      padding: 10px;
+    }
+
+    p {
+      margin: 0;
+    }
+    </style>
+  </head>
+  <body>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js" data-presets="es2015,stage-2"></script>
+    <script crossorigin src="https://unpkg.com/react@16/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/prop-types@15.6/prop-types.js"></script>
+    <script type="text/javascript">
+    window.react = window.React;
+    window['prop-types'] = window.PropTypes;
+    </script>
+    <script src="../VirtualList.js"></script>
+    <div id="example"></div>
+    <script type="text/babel">
+    (function() {
+      const lorem = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer ante orci, tincidunt at malesuada sed, mollis vel nunc. Duis sed dolor a sem varius egestas vitae id nulla. Donec venenatis mollis tellus at sollicitudin. Vestibulum in enim dictum, tincidunt diam ut, posuere metus. Curabitur vel urna nisl. Etiam nisi orci, tincidunt et dignissim ac, auctor quis lorem. Curabitur condimentum nulla vel iaculis feugiat. Donec aliquam fermentum neque, sit amet venenatis est molestie non. Morbi pulvinar risus turpis, id pellentesque nibh malesuada ac. Vivamus lacinia tincidunt nibh sed porta. Donec porttitor mauris eu venenatis laoreet. Fusce augue orci, vehicula ut venenatis sit amet, laoreet vitae augue. In hac habitasse platea dictumst. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. In ornare vitae dui a accumsan. Nam tincidunt volutpat sem, quis venenatis nulla fermentum eget. Curabitur dictum commodo massa, ut facilisis lacus pharetra sed.".split(/\s+/);
+      const items = [];
+
+      for (let i = 0; i < 1000; i++) {
+        items.push({id: i, name: 'item: ' + i});
+      }
+
+      const ItemView = ({ item }) => (
+        <div className="ItemView" style={{height: 50}}>
+          <p>{item.name}</p>
+        </div>
+      );
+      class App extends React.Component {
+        state = {
+          first: null
+        }
+
+        render() {
+          const { first } = this.state;
+          return (
+            <div>
+              <div>
+                First visible index: {first && first.id}
+              </div>
+              <div className="container">
+                <VirtualList
+                  items={items}
+                  getItemKey={(item, index) => item.id}
+                  onFirstVisibleItemChange={item => this.setState({ first: item })}
+                >
+                  <ItemView />
+                </VirtualList>
+              </div>
+            </div>
+          );
+        }
+      }
+      ReactDOM.render(<App ref={app => window.app = app} />, document.querySelector('#example'));
+      window.items = items;
+    }());
+    </script>
+  </body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,6 +13,7 @@
       <li><a href="./examples/1.html">Example 1</a>
       <li><a href="./examples/2.html">Example 2</a>
       <li><a href="./examples/3.html">Example 3</a>
+      <li><a href="./examples/4.html">Example 4</a>
     </ul>
   </body>
 </html>

--- a/pkg/VirtualList.js
+++ b/pkg/VirtualList.js
@@ -443,8 +443,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return this;
 	    }
 	  }, {
-	    key: 'scrollToIndex',
-	    value: function scrollToIndex(index, callback) {
+	    key: '_scrollToIndex',
+	    value: function _scrollToIndex(index, callback) {
 	      var items = this.props.items;
 	      var _state9 = this.state,
 	          winSize = _state9.winSize,
@@ -455,6 +455,23 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var scrollTop = winStart * avgRowHeight;
 
 	      this.setState({ winStart: winStart, scrollTop: scrollTop }, callback);
+	    }
+	  }, {
+	    key: 'scrollToIndex',
+	    value: function scrollToIndex(index, callback) {
+	      var _this4 = this;
+
+	      if (this.state.avgRowHeight === 1) {
+	        // The average row height is still the initial value, which means that we
+	        // haven't sampled the row heights yet, which we need in order to properly
+	        // scroll to the right position. So we need to delay the scroll logic
+	        // until after the list has had a chance to sample the row heights.
+	        this.setState({}, function () {
+	          _this4._scrollToIndex(index, callback);
+	        });
+	      } else {
+	        this._scrollToIndex(index, callback);
+	      }
 	    }
 	  }, {
 	    key: 'scrollToItem',
@@ -514,7 +531,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }, {
 	    key: 'render',
 	    value: function render() {
-	      var _this4 = this;
+	      var _this5 = this;
 
 	      var _props2 = this.props,
 	          items = _props2.items,
@@ -561,7 +578,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        'div',
 	        {
 	          ref: function ref(node) {
-	            _this4.node = node;
+	            _this5.node = node;
 	          },
 	          className: 'VirtualList',
 	          tabIndex: '-1',
@@ -571,7 +588,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	          'div',
 	          {
 	            ref: function ref(content) {
-	              _this4.content = content;
+	              _this5.content = content;
 	            },
 	            className: 'VirtualList-content',
 	            style: contentStyle },

--- a/pkg/VirtualList.js
+++ b/pkg/VirtualList.js
@@ -445,6 +445,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }, {
 	    key: '_scrollToIndex',
 	    value: function _scrollToIndex(index, callback) {
+	      var _this4 = this;
+
 	      var items = this.props.items;
 	      var _state9 = this.state,
 	          winSize = _state9.winSize,
@@ -454,12 +456,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var winStart = Math.min(maxWinStart, index);
 	      var scrollTop = winStart * avgRowHeight;
 
-	      this.setState({ winStart: winStart, scrollTop: scrollTop }, callback);
+	      this.setState({ winStart: winStart, scrollTop: scrollTop }, function () {
+	        _this4.content.childNodes[index - winStart].scrollIntoView();
+	      });
 	    }
 	  }, {
 	    key: 'scrollToIndex',
 	    value: function scrollToIndex(index, callback) {
-	      var _this4 = this;
+	      var _this5 = this;
 
 	      if (this.state.avgRowHeight === 1) {
 	        // The average row height is still the initial value, which means that we
@@ -467,7 +471,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        // scroll to the right position. So we need to delay the scroll logic
 	        // until after the list has had a chance to sample the row heights.
 	        this.setState({}, function () {
-	          _this4._scrollToIndex(index, callback);
+	          _this5._scrollToIndex(index, callback);
 	        });
 	      } else {
 	        this._scrollToIndex(index, callback);
@@ -516,22 +520,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return this;
 	    }
 	  }, {
-	    key: 'handleScroll',
-	    value: function handleScroll() {
-	      var node = this.node;
-	      var scrollTop = this.state.scrollTop;
-
-
-	      if (node.scrollTop !== scrollTop) {
-	        this.scroll(node.scrollTop - scrollTop);
-	      }
-
-	      this._handleScrollRAF = requestAnimationFrame(this.handleScroll);
-	    }
-	  }, {
 	    key: 'render',
 	    value: function render() {
-	      var _this5 = this;
+	      var _this6 = this;
 
 	      var _props2 = this.props,
 	          items = _props2.items,
@@ -578,7 +569,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        'div',
 	        {
 	          ref: function ref(node) {
-	            _this5.node = node;
+	            _this6.node = node;
 	          },
 	          className: 'VirtualList',
 	          tabIndex: '-1',
@@ -588,7 +579,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	          'div',
 	          {
 	            ref: function ref(content) {
-	              _this5.content = content;
+	              _this6.content = content;
 	            },
 	            className: 'VirtualList-content',
 	            style: contentStyle },

--- a/pkg/VirtualList.js
+++ b/pkg/VirtualList.js
@@ -328,7 +328,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }, {
 	    key: 'handleScroll',
 	    value: function handleScroll(callback) {
-	      var items = this.props.items;
+	      var _props2 = this.props,
+	          items = _props2.items,
+	          buffer = _props2.buffer;
 
 	      var itemNodes = Array.from(this.content.childNodes).slice(1, -1);
 	      var firstItemNode = itemNodes[0];
@@ -348,8 +350,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	        newWinStart = Math.min(maxWinStart, Math.floor(scrollTop / avgRowHeight));
 	      } else if (firstItemNode && firstItemNode.offsetTop + firstItemNode.offsetHeight > scrollTop) {
 	        // first item is visible, so shift window upwards
-	        for (var i = itemNodes.length - 1; i > 0; i--) {
-	          if (newWinStart > 0 && itemNodes[i].offsetTop > scrollTop + viewportHeight && itemNodes[i - 1].offsetTop > scrollTop + viewportHeight) {
+	        for (var i = 0; i < Math.ceil(buffer / 2); i++) {
+	          if (newWinStart > 0 && itemNodes[itemNodes.length - i - 1].offsetTop > scrollTop + viewportHeight) {
 	            newWinStart--;
 	          } else {
 	            break;
@@ -357,8 +359,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	        }
 	      } else if (lastItemNode && lastItemNode.offsetTop < scrollTop + viewportHeight) {
 	        // last item is visible, so shift window downwards
-	        for (var _i = 0; _i < itemNodes.length - 1; _i++) {
-	          if (newWinStart < maxWinStart && itemNodes[_i].offsetTop + itemNodes[_i].offsetHeight < scrollTop && itemNodes[_i + 1].offsetTop + itemNodes[_i + 1].offsetHeight < scrollTop) {
+	        for (var _i = 0; _i < Math.ceil(buffer / 2); _i++) {
+	          if (newWinStart < maxWinStart && itemNodes[_i].offsetTop + itemNodes[_i].offsetHeight < scrollTop) {
 	            newWinStart++;
 	          } else {
 	            break;
@@ -456,11 +458,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    value: function render() {
 	      var _this6 = this;
 
-	      var _props2 = this.props,
-	          items = _props2.items,
-	          getItem = _props2.getItem,
-	          getItemKey = _props2.getItemKey,
-	          scrollbarOffset = _props2.scrollbarOffset;
+	      var _props3 = this.props,
+	          items = _props3.items,
+	          getItem = _props3.getItem,
+	          getItemKey = _props3.getItemKey,
+	          scrollbarOffset = _props3.scrollbarOffset;
 	      var _state6 = this.state,
 	          winStart = _state6.winStart,
 	          winSize = _state6.winSize,

--- a/pkg/VirtualList.js
+++ b/pkg/VirtualList.js
@@ -299,7 +299,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 	      for (var i = 0; i < itemNodes.length; i++) {
-	        if (itemNodes[i].offsetTop + itemNodes[i].offsetHeight >= scrollTop) {
+	        if (itemNodes[i].offsetTop + itemNodes[i].offsetHeight > scrollTop) {
 	          return winStart + i;
 	        }
 	      }

--- a/pkg/VirtualList.js
+++ b/pkg/VirtualList.js
@@ -452,12 +452,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	          winSize = _state9.winSize,
 	          avgRowHeight = _state9.avgRowHeight;
 
-
-	      if (index >= winStart && index < winStart + winSize) {
-	        this.content.childNodes[index - winStart].scrollIntoView();
-	        if (callback) callback();
-	        return;
-	      }
+	      //if (index >= winStart && index < winStart + winSize) {
+	      //  this.content.childNodes[index - winStart].scrollIntoView();
+	      //  if (callback) callback();
+	      //  return;
+	      //}
 
 	      var items = this.props.items;
 

--- a/pkg/VirtualList.js
+++ b/pkg/VirtualList.js
@@ -447,17 +447,27 @@ return /******/ (function(modules) { // webpackBootstrap
 	    value: function _scrollToIndex(index, callback) {
 	      var _this4 = this;
 
-	      var items = this.props.items;
 	      var _state9 = this.state,
+	          winStart = _state9.winStart,
 	          winSize = _state9.winSize,
 	          avgRowHeight = _state9.avgRowHeight;
 
-	      var maxWinStart = Math.max(0, items.length - winSize);
-	      var winStart = Math.min(maxWinStart, index);
-	      var scrollTop = winStart * avgRowHeight;
 
-	      this.setState({ winStart: winStart, scrollTop: scrollTop }, function () {
-	        _this4.content.childNodes[index - winStart].scrollIntoView();
+	      if (index >= winStart && index < winStart + winSize) {
+	        this.content.childNodes[index - winStart].scrollIntoView();
+	        if (callback) callback();
+	        return;
+	      }
+
+	      var items = this.props.items;
+
+	      var maxWinStart = Math.max(0, items.length - winSize);
+	      var newWinStart = Math.min(maxWinStart, index);
+	      var scrollTop = newWinStart * avgRowHeight;
+
+	      this.setState({ winStart: newWinStart, scrollTop: scrollTop }, function () {
+	        _this4.content.childNodes[index - newWinStart].scrollIntoView();
+	        if (callback) callback();
 	      });
 	    }
 	  }, {

--- a/spec/VirtualList_spec.js
+++ b/spec/VirtualList_spec.js
@@ -64,6 +64,7 @@ describe('VirtualList', function() {
     this.setupList = props => {
       ReactDOM.render(
         <Container
+          buffer={4}
           items={this.items}
           ref={el => {
             this.container = el;
@@ -101,7 +102,7 @@ describe('VirtualList', function() {
     });
 
     it('calculates the window size based on the viewportHeight and average row height', function() {
-      expect(this.list.state.winSize).toBe(11);
+      expect(this.list.state.winSize).toBe(7 + this.list.props.buffer);
     });
   });
 
@@ -115,12 +116,14 @@ describe('VirtualList', function() {
       expect(this.node.style.overflowY).toBe('auto');
     });
 
-    it('renders a content node with a padding-top of 0', function() {
-      expect(this.contentNode.style.paddingTop).toBe('0px');
+    it('renders a content node two buffer child nodes', function() {
+      expect(this.contentNode.childNodes[0].className).toBe('VirtualList-buffer');
+      expect(this.contentNode.childNodes[this.contentNode.childNodes.length - 1].className).toBe('VirtualList-buffer');
     });
 
-    it('sets the padding-bottom of the content node to the number of items not rendered times the average item row height', function() {
-      expect(this.contentNode.style.paddingBottom).toBe('2670px');
+    it('sets the height of the bottom buffer node to the number of items not rendered times the average item row height', function() {
+      const buf = this.contentNode.childNodes[this.contentNode.childNodes.length - 1];
+      expect(buf.style.height).toBe('2670px');
     });
 
     it('renders the number of item rows as indicated by the winSize state prop', function() {
@@ -150,53 +153,45 @@ describe('VirtualList', function() {
 
     describe('on a short downward scroll', function() {
       beforeEach(function(done) {
-        this.list.scroll(41, done);
+        this.node.scrollTop += 101;
+        requestAnimationFrame(done);
       });
 
-      it('recalculates the window start based on the number of items scrolled out of view', function() {
-        expect(this.list.state.winStart).toBe(1);
+      it('recalculates the window start when the last item becomes visible', function() {
+        expect(this.list.state.winStart).toBe(2);
       });
 
-      it('sets the padding-top of the content node to the average row height times the number of non-rendered items', function() {
-        expect(this.contentNode.style.paddingTop).toBe('30px');
-      });
-
-      it('re-adjusts the scrollTop to account for the difference in the average row height and the height of the item removed', function() {
-        expect(this.list.state.scrollTop).toBe(31);
+      it('sets the height of the top buffer node to the average row height times the number of non-rendered items', function() {
+        expect(this.contentNode.childNodes[0].style.height).toBe('60px');
       });
     });
 
     describe('on a short upward scroll', function() {
       beforeEach(function(done) {
         this.list.scrollToIndex(20, () => {
-          this.list.scroll(-1, done);
+          this.node.scrollTop -= 1;
+          requestAnimationFrame(done);
         });
       });
 
       it('recalculates the window start based on the number of items scrolled out of view', function() {
         // winSize is 11
         // 5 items at 40px each take up the viewport
-        // 6 items are out of view after the scroll
-        expect(this.list.state.winStart).toBe(14);
+        // 6 items are out of view after the scroll, so window will slide up by 5
+        expect(this.list.state.winStart).toBe(15);
       });
 
-      it('sets the padding-top of the content node to the average row height times the number of non-rendered items', function() {
-        // 14 items not rendered times 30px avg height
-        expect(this.contentNode.style.paddingTop).toBe('420px');
-      });
-
-      it('re-adjusts the scrollTop to account for the difference in the average row height and the height of the newly rendered items at the beginning of the window', function() {
-        // scrollTop starts at 600px (20 items not rendered * 30px avg height)
-        // 6 items at 40px each of height are rendered at the beginning
-        // 600px - 1px scroll + (6 * 10px difference)
-        expect(this.list.state.scrollTop).toBe(659);
+      it('sets the height of the top buffer node to the average row height times the number of non-rendered items', function() {
+        // 15 items not rendered times 30px avg height
+        expect(this.contentNode.childNodes[0].style.height).toBe('450px');
       });
     });
   });
 
   describe('on a downward scroll past the end of the list', function() {
     beforeEach(function(done) {
-      this.list.scroll(20000000, done);
+      this.node.scrollTop += 20000000;
+      requestAnimationFrame(done);
     });
 
     it('does not adjust the window past the end of the list', function() {
@@ -206,7 +201,8 @@ describe('VirtualList', function() {
 
   describe('on an upward scroll past the beginning of the list', function() {
     beforeEach(function(done) {
-      this.list.scroll(-50, done);
+      this.node.scrollTop -= 50;
+      requestAnimationFrame(done);
     });
 
     it('does not adjust the window past the beginning of the list', function() {
@@ -216,30 +212,29 @@ describe('VirtualList', function() {
 
   describe('on a long scroll', function() {
     beforeEach(function(done) {
-      this.list.scroll(1201, done);
+      this.node.scrollTop += 1201;
+      requestAnimationFrame(done);
     });
 
     it('sets the window start to the item nearest the scroll postion based on average row height', function() {
       expect(this.list.state.winStart).toBe(40);
     });
 
-    it('sets the padding-top of the content node to the average row height times the number of non-rendered items', function() {
+    it('sets the height of the top buffer node to the average row height times the number of non-rendered items', function() {
       // 40 items not rendered times 30px avg height
-      expect(this.contentNode.style.paddingTop).toBe('1200px');
-    });
-
-    it('sets the scrollTop', function() {
-      expect(this.list.state.scrollTop).toBe(1201);
+      expect(this.contentNode.childNodes[0].style.height).toBe('1200px');
     });
   });
 
   describe('onFirstVisibleItemChange callback', function() {
-    it('gets invoked after a scroll changes which item is the first visibile', function(done) {
+    it('gets invoked after a scroll changes which item is the first visible', function(done) {
       expect(this.onFirstVisibleItemChange.calls.count()).toBe(1);
 
-      this.list.scroll(39, () => {
+      this.node.scrollTop += 39;
+      requestAnimationFrame(() => {
         expect(this.onFirstVisibleItemChange.calls.count()).toBe(1);
-        this.list.scroll(2, () => {
+        this.node.scrollTop += 2;
+        requestAnimationFrame(() => {
           expect(this.onFirstVisibleItemChange.calls.count()).toBe(2);
           expect(this.onFirstVisibleItemChange).toHaveBeenCalledWith(
             this.items[1],
@@ -252,13 +247,19 @@ describe('VirtualList', function() {
   });
 
   describe('onLastVisibleItemChange callback', function() {
-    it('gets invoked after a scroll changes which item is the last visibile', function(done) {
-      expect(this.onLastVisibleItemChange.calls.count()).toBe(1);
+    beforeEach(function(done) {
+      requestAnimationFrame(done);
+    });
 
-      this.list.scroll(19, () => {
-        expect(this.onLastVisibleItemChange.calls.count()).toBe(1);
-        this.list.scroll(2, () => {
-          expect(this.onLastVisibleItemChange.calls.count()).toBe(2);
+    it('gets invoked after a scroll changes which item is the last visible', function(done) {
+      expect(this.onLastVisibleItemChange.calls.count()).toBe(2);
+
+      this.node.scrollTop += 19;
+      requestAnimationFrame(() => {
+        expect(this.onLastVisibleItemChange.calls.count()).toBe(2);
+        this.node.scrollTop += 2;
+        requestAnimationFrame(() => {
+          expect(this.onLastVisibleItemChange.calls.count()).toBe(3);
           expect(this.onLastVisibleItemChange).toHaveBeenCalledWith(
             this.items[7],
             7,

--- a/spec/VirtualList_spec.js
+++ b/spec/VirtualList_spec.js
@@ -175,15 +175,16 @@ describe('VirtualList', function() {
       });
 
       it('recalculates the window start based on the number of items scrolled out of view', function() {
+        // buffer is 4
         // winSize is 11
         // 5 items at 40px each take up the viewport
-        // 6 items are out of view after the scroll, so window will slide up by 5
-        expect(this.list.state.winStart).toBe(15);
+        // 6 items are out of view after the scroll, so window will slide up by 2 (half the buffer)
+        expect(this.list.state.winStart).toBe(18);
       });
 
       it('sets the height of the top buffer node to the average row height times the number of non-rendered items', function() {
-        // 15 items not rendered times 30px avg height
-        expect(this.contentNode.childNodes[0].style.height).toBe('450px');
+        // 18 items not rendered times 30px avg height
+        expect(this.contentNode.childNodes[0].style.height).toBe('540px');
       });
     });
   });

--- a/src/VirtualList.jsx
+++ b/src/VirtualList.jsx
@@ -311,7 +311,7 @@ class VirtualList extends React.Component {
     return this;
   }
 
-  scrollToIndex(index, callback) {
+  _scrollToIndex(index, callback) {
     const {items} = this.props;
     const {winSize, avgRowHeight} = this.state;
     const maxWinStart = Math.max(0, items.length - winSize);
@@ -319,6 +319,20 @@ class VirtualList extends React.Component {
     let scrollTop = winStart * avgRowHeight;
 
     this.setState({winStart, scrollTop}, callback);
+  }
+
+  scrollToIndex(index, callback) {
+    if (this.state.avgRowHeight === 1) {
+      // The average row height is still the initial value, which means that we
+      // haven't sampled the row heights yet, which we need in order to properly
+      // scroll to the right position. So we need to delay the scroll logic
+      // until after the list has had a chance to sample the row heights.
+      this.setState({}, () => {
+        this._scrollToIndex(index, callback);
+      });
+    } else {
+      this._scrollToIndex(index, callback);
+    }
   }
 
   scrollToItem(item, callback) {

--- a/src/VirtualList.jsx
+++ b/src/VirtualList.jsx
@@ -312,14 +312,22 @@ class VirtualList extends React.Component {
   }
 
   _scrollToIndex(index, callback) {
-    const {items} = this.props;
-    const {winSize, avgRowHeight} = this.state;
-    const maxWinStart = Math.max(0, items.length - winSize);
-    let winStart = Math.min(maxWinStart, index);
-    let scrollTop = winStart * avgRowHeight;
+    const {winStart, winSize, avgRowHeight} = this.state;
 
-    this.setState({winStart, scrollTop}, () => {
+    if (index >= winStart && index < winStart + winSize) {
       this.content.childNodes[index - winStart].scrollIntoView();
+      if (callback) callback();
+      return;
+    }
+
+    const {items} = this.props;
+    const maxWinStart = Math.max(0, items.length - winSize);
+    let newWinStart = Math.min(maxWinStart, index);
+    let scrollTop = newWinStart * avgRowHeight;
+
+    this.setState({winStart: newWinStart, scrollTop}, () => {
+      this.content.childNodes[index - newWinStart].scrollIntoView();
+      if (callback) callback();
     });
   }
 

--- a/src/VirtualList.jsx
+++ b/src/VirtualList.jsx
@@ -318,7 +318,9 @@ class VirtualList extends React.Component {
     let winStart = Math.min(maxWinStart, index);
     let scrollTop = winStart * avgRowHeight;
 
-    this.setState({winStart, scrollTop}, callback);
+    this.setState({winStart, scrollTop}, () => {
+      this.content.childNodes[index - winStart].scrollIntoView();
+    });
   }
 
   scrollToIndex(index, callback) {
@@ -367,17 +369,6 @@ class VirtualList extends React.Component {
     }
 
     return this;
-  }
-
-  handleScroll() {
-    const node = this.node;
-    const { scrollTop } = this.state;
-
-    if (node.scrollTop !== scrollTop) {
-      this.scroll(node.scrollTop - scrollTop);
-    }
-
-    this._handleScrollRAF = requestAnimationFrame(this.handleScroll);
   }
 
   render() {

--- a/src/VirtualList.jsx
+++ b/src/VirtualList.jsx
@@ -209,7 +209,7 @@ class VirtualList extends React.Component {
   }
 
   handleScroll(callback) {
-    const {items} = this.props;
+    const {items, buffer} = this.props;
     const itemNodes = Array.from(this.content.childNodes).slice(1, -1);
     const firstItemNode = itemNodes[0];
     const lastItemNode = itemNodes[itemNodes.length - 1];
@@ -227,11 +227,10 @@ class VirtualList extends React.Component {
       newWinStart = Math.min(maxWinStart, Math.floor(scrollTop / avgRowHeight));
     } else if (firstItemNode && firstItemNode.offsetTop + firstItemNode.offsetHeight > scrollTop) {
       // first item is visible, so shift window upwards
-      for (let i = itemNodes.length - 1; i > 0; i--) {
+      for (let i = 0; i < Math.ceil(buffer / 2); i++) {
         if (
           newWinStart > 0 &&
-          itemNodes[i].offsetTop > scrollTop + viewportHeight &&
-          itemNodes[i-1].offsetTop > scrollTop + viewportHeight
+          itemNodes[itemNodes.length - i - 1].offsetTop > scrollTop + viewportHeight
         ) {
           newWinStart--;
         } else {
@@ -240,11 +239,10 @@ class VirtualList extends React.Component {
       }
     } else if (lastItemNode && lastItemNode.offsetTop < scrollTop + viewportHeight) {
       // last item is visible, so shift window downwards
-      for (let i = 0; i < itemNodes.length - 1; i++) {
+      for (let i = 0; i < Math.ceil(buffer / 2); i++) {
         if (
           newWinStart < maxWinStart &&
-          itemNodes[i].offsetTop + itemNodes[i].offsetHeight < scrollTop &&
-          itemNodes[i+1].offsetTop + itemNodes[i+1].offsetHeight < scrollTop
+          itemNodes[i].offsetTop + itemNodes[i].offsetHeight < scrollTop
         ) {
           newWinStart++;
         } else {

--- a/src/VirtualList.jsx
+++ b/src/VirtualList.jsx
@@ -314,12 +314,6 @@ class VirtualList extends React.Component {
   _scrollToIndex(index, callback) {
     const {winStart, winSize, avgRowHeight} = this.state;
 
-    if (index >= winStart && index < winStart + winSize) {
-      this.content.childNodes[index - winStart].scrollIntoView();
-      if (callback) callback();
-      return;
-    }
-
     const {items} = this.props;
     const maxWinStart = Math.max(0, items.length - winSize);
     let newWinStart = Math.min(maxWinStart, index);

--- a/src/VirtualList.jsx
+++ b/src/VirtualList.jsx
@@ -185,7 +185,7 @@ class VirtualList extends React.Component {
     const {winStart} = this.state;
 
     for (let i = 0; i < itemNodes.length; i++) {
-      if (itemNodes[i].offsetTop + itemNodes[i].offsetHeight >= scrollTop) {
+      if (itemNodes[i].offsetTop + itemNodes[i].offsetHeight > scrollTop) {
         return winStart + i;
       }
     }


### PR DESCRIPTION
This PR fixes a couple of bugs related to scrolling:

1. There is a bug with the `scrollToIndex` method when it is called immediately after the component first renders. The bug is due to the fact that row heights have not been sampled yet and thus an invalid value is computed for the `scrollTop` state variable. The fix is to simply detect this case and delay running the scroll logic until after the row heights have been sampled.
2. Jitter when scrolling upward by clicking and dragging the scroll bar. This was occurring because the browser automatically adjusts the scroll position to accommodate height changes of items above the viewport. Sometimes this adjustment would result in a downward scroll, which would counter the initial upward scroll. To fix this issue I simplified how scrolling is handled by just looking at the first and last rendered items on each animation frame. If one or the other is visible, then the window is adjusted accordingly. This means that we don't have to detect the direction of the scroll or track the node's `scrollTop` property on state so we avoid any unwanted automatic downward scrolls after an upward scroll by the user.